### PR TITLE
Provider implementation and doc

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -452,7 +452,7 @@ _flags_profiles2=no_require
 
 <h4 id="uri-schema-provider">URI schema: <code>provider</code></h4>
 
-The provider schema is a way to load default configuration provided by modules your
+The {@value io.jstach.ezkv.kvs.KeyValuesResource#SCHEMA_PROVIDER} schema is a way to load default configuration provided by modules your
 application depends on for example a database layer or service layer. 
 The providers should be registered as ServiceLoader services so that they can be discovered
 however they will not be loaded unless this schema is used.

--- a/doc/overview.html
+++ b/doc/overview.html
@@ -376,6 +376,7 @@ based on the schema of the URI. For example:</p>
     <li>{@value io.jstach.ezkv.kvs.KeyValuesResource#SCHEMA_CMD} - Command line argument pairs separated by <code>=</code></li>
     <li>{@value io.jstach.ezkv.kvs.KeyValuesResource#SCHEMA_STDIN} - Allows Unix piping of key values, often useful for passwords</li>
     <li>{@value io.jstach.ezkv.kvs.KeyValuesResource#SCHEMA_PROFILE} - Will load multiple resources based on a CSV of profiles where the profile name replaces part of the URI</li>
+    <li>{@value io.jstach.ezkv.kvs.KeyValuesResource#SCHEMA_PROVIDER} - Will load reference config that is usually loaded from the ServiceLoader</li>
 </ul>
 
 
@@ -448,6 +449,45 @@ _flags_profiles2=no_require
 }
 
 <p>This means users can create a similar implementation themselves if desired.</p>
+
+<h4 id="uri-schema-provider">URI schema: <code>provider</code></h4>
+
+The provider schema is a way to load default configuration provided by modules your
+application depends on for example a database layer or service layer. 
+The providers should be registered as ServiceLoader services so that they can be discovered
+however they will not be loaded unless this schema is used.
+<p>
+This is akin to
+<a href="https://github.com/lightbend/config?tab=readme-ov-file#standard-behavior">
+Lightbend/Typesafe Config <code>reference.conf</code></a> but without a resource
+call for maximum portability with things like GraalVM native, and modular applications
+where the config could be an enscapulated resource (properties file) which would
+require the module to do the loading and not EZKV.
+</p>
+
+<strong>Example:</strong>
+
+{@snippet lang=properties :
+# It desirable to load the providers very early if possible
+# as the idea is to have the config replaced with downstream key values
+_load_providers=provider:///
+}
+
+In our database layer we would create a class like:
+
+{@snippet :
+class DatabaseConfigProvider implements KeyValuesServiceProvider.KeyValuesProvider {
+
+	@Override
+	public void provide(KeyValues.Builder builder) {
+		builder.add("database.port", "5245");
+	}
+
+}
+}
+
+And then register it using the {@link java.util.ServiceLoader} registration with
+the service class of {@link io.jstach.ezkv.kvs.KeyValuesServiceProvider}.
 
 <h3 id="keyvaluesmedia">KeyValuesMedia</h3>
 

--- a/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesResource.java
+++ b/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesResource.java
@@ -44,6 +44,10 @@ import io.jstach.ezkv.kvs.Variables.Parameters;
  * <li>{@value io.jstach.ezkv.kvs.KeyValuesResource#SCHEMA_PROFILE} - Will load multiple
  * resources based on a CSV of profiles where the profile name replaces part of the
  * URI</li>
+ * <li>{@value io.jstach.ezkv.kvs.KeyValuesResource#SCHEMA_PROVIDER} - Will load reference
+ * key values provided from other modules/layers and is way for other modules/layers to
+ * share default configuration. See {@link KeyValuesServiceProvider.KeyValuesProvider}.
+ * </li>
  * </ul>
  *
  * <h2>Resource Keys</h2>
@@ -397,6 +401,27 @@ public sealed interface KeyValuesResource extends NamedKeyValuesSource, KeyValue
 	 */
 	// @formatter:on
 	public static final String SCHEMA_CLASSPATH = "classpath";
+
+	// @formatter:off
+	/**
+	 * Will load provider(s) reference key values.
+	 *
+	 * {@snippet lang=properties :
+	 * # load all providers registered
+	 * _load_providers=provider:///
+	 * # or load a specific provider from another module
+	 * _load_provider_db=provider:///RepositoryLayerKeyValuesProvider
+	 * }
+	 *
+	 * It is recommend that you do enable the service loader
+	 * with {@link KeyValuesSystem.Builder#useServiceLoader()}
+	 * and that you use this resource schema very early so
+	 * that downstream key values can override it.
+	 *
+	 * @see KeyValuesServiceProvider.KeyValuesProvider
+	 */
+	// @formatter:on
+	public static final String SCHEMA_PROVIDER = "provider";
 
 	// @formatter:off
 	/**

--- a/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesServiceProvider.java
+++ b/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesServiceProvider.java
@@ -79,10 +79,28 @@ public sealed interface KeyValuesServiceProvider {
 	 * unnecessary coupling if all they are doing is just providing reference config.
 	 * <p>
 	 * <strong>NOTE:</strong> It is recommend to avoid making key values that need
-	 * interpolation as the variables may not be present. The idea again is that this
-	 * reference config that needs to be guaranteed to be there for defaults and possibly
-	 * participate in downstream variable/interpolation usage.
+	 * interpolation from external variables as the variables may not be present. However
+	 * interpolation based on the local keys being added is fine and encouraged (for
+	 * example constructing a JDBC URL from a default port that is also provided). The
+	 * idea again is that this reference config that needs to be guaranteed to be there
+	 * for defaults and possibly participate in downstream variable/interpolation usage.
 	 *
+	 * <strong>Example</strong>
+	 * {@snippet :
+	 * class DatabaseConfigProvider implements KeyValuesServiceProvider.KeyValuesProvider {
+	 *
+	 * 	public void provide(KeyValues.Builder builder) {
+	 * 		builder.add("database.host", "localhost");
+	 * 		builder.add("database.port", "5245");
+	 * 		builder.add("database.schema", "mydb");
+	 * 		builder.add("database.url", "jdbc:postgresql://${database.host}/${database.port}/${database.schema}");
+	 * 	}
+	 *
+	 * }
+	 * }
+	 * 
+	 * Down stream <code>database.port</code> could be overriden.
+	 * 
 	 * @see KeyValuesResource#SCHEMA_PROVIDER
 	 */
 	public non-sealed interface KeyValuesProvider extends KeyValuesServiceProvider {


### PR DESCRIPTION
The provider schema is a way to load default configuration provided by modules your application depends on for example a database layer or service layer. The providers should be registered as ServiceLoader services so that they can be discovered however they will not be loaded unless this schema is used.

This is akin to [Lightbend/Typesafe Config reference.conf](https://github.com/lightbend/config?tab=readme-ov-file#standard-behavior) but without a resource call for maximum portability with things like GraalVM native, and modular applications where the config could be an enscapulated resource (properties file) which would require the module to do the loading and not EZKV.