### PR TITLE
Implicit filters to support things like spring.config.activate.on-profile

### DIFF
--- a/ezkv-boot/src/main/java/io/jstach/ezkv/boot/EzkvConfig.java
+++ b/ezkv-boot/src/main/java/io/jstach/ezkv/boot/EzkvConfig.java
@@ -138,7 +138,7 @@ class QueueLogger implements Logger {
 
 	@Override
 	public void init(KeyValuesSystem system) {
-		events.add(new Event(System.Logger.Level.INFO, "Initializing"));
+		events.add(new Event(System.Logger.Level.DEBUG, "Initializing"));
 	}
 
 	@Override
@@ -159,7 +159,7 @@ class QueueLogger implements Logger {
 
 	@Override
 	public void closed(KeyValuesSystem system) {
-		System.Logger logger = System.getLogger("io.jstach.ezkv.boot.ezkvConfig");
+		System.Logger logger = System.getLogger("io.jstach.ezkv.boot.EzkvConfig");
 		Event e;
 		while ((e = events.poll()) != null) {
 			logger.log(e.level, e.message);
@@ -171,9 +171,9 @@ class QueueLogger implements Logger {
 		var err = System.err;
 		Event e;
 		while ((e = events.poll()) != null) {
-			err.println("[" + Logger.formatLevel(e.level) + "] io.jstach.ezkv.boot.ezkvConfig - " + e.message);
+			err.println("[" + Logger.formatLevel(e.level) + "] io.jstach.ezkv.boot.EzkvConfig - " + e.message);
 		}
-		err.println("[ERROR] io.jstach.ezkv.boot.ezkvConfig - " + exception.getMessage());
+		err.println("[ERROR] io.jstach.ezkv.boot.EzkvConfig - " + exception.getMessage());
 		exception.printStackTrace(err);
 	}
 
@@ -201,6 +201,8 @@ final class Holder {
 		try (var system = KeyValuesSystem.builder() //
 			.useServiceLoader()
 			.environment(new BootEnvironment(logger))
+			.filter(new OnProfileKeyValuesFilter())
+			.addPreFilter("onprofile", "")
 			.build()) {
 			var properties = Holder.PROPERTIES;
 
@@ -209,7 +211,8 @@ final class Holder {
 			if (properties != null) {
 				loader.add("setDefaultProperties", properties);
 			}
-			var kvs = loader.variables(Variables::ofSystemProperties)
+			var kvs = loader //
+				.variables(Variables::ofSystemProperties)
 				.variables(Variables::ofSystemEnv)
 				.variables(RandomVariables::of)
 				.add("classpath:/application.properties", b -> b.name("application").noRequire(true))

--- a/ezkv-boot/src/main/java/io/jstach/ezkv/boot/OnProfileKeyValuesFilter.java
+++ b/ezkv-boot/src/main/java/io/jstach/ezkv/boot/OnProfileKeyValuesFilter.java
@@ -1,0 +1,33 @@
+package io.jstach.ezkv.boot;
+
+import java.util.Optional;
+import java.util.Set;
+
+import io.jstach.ezkv.kvs.KeyValues;
+import io.jstach.ezkv.kvs.KeyValuesException;
+import io.jstach.ezkv.kvs.KeyValuesServiceProvider.KeyValuesFilter;
+
+class OnProfileKeyValuesFilter implements KeyValuesFilter {
+
+	@Override
+	public Optional<KeyValues> filter(FilterContext context, KeyValues keyValues, Filter filter)
+			throws IllegalArgumentException, KeyValuesException {
+		if (!filter.filter().equals("onprofile")) {
+			return Optional.empty();
+		}
+		var map = keyValues.toMap();
+		String activateOn = context.environment().qualifyMetaKey("config.activate.on-profile");
+		String profileExp = map.get(activateOn);
+		if (profileExp == null) {
+			return Optional.of(keyValues);
+		}
+		// context.environment().getLogger().debug("Found profile exp: " + profileExp);
+		var _profiles = Profiles.of(profileExp);
+		var selectedProfiles = Set.copyOf(context.profiles());
+		if (_profiles.matches(selectedProfiles::contains)) {
+			return Optional.of(keyValues.filter(kv -> !kv.key().equals(activateOn)));
+		}
+		return Optional.of(KeyValues.empty());
+	}
+
+}

--- a/ezkv-boot/src/main/java/io/jstach/ezkv/boot/Profiles.java
+++ b/ezkv-boot/src/main/java/io/jstach/ezkv/boot/Profiles.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jstach.ezkv.boot;
+
+import java.util.function.Predicate;
+
+// TODO possibly move to ezkv-kvs
+/**
+ * Profile predicate that may be {@linkplain Environment#acceptsProfiles(Profiles)
+ * accepted} by an {@link Environment}.
+ *
+ * <p>
+ * May be implemented directly or, more usually, created using the {@link #of(String...)
+ * of(...)} factory method.
+ *
+ * @author Phillip Webb
+ * @author Sam Brannen
+ * @since 5.1
+ * @see Environment#acceptsProfiles(Profiles)
+ * @see Environment#matchesProfiles(String...)
+ */
+@FunctionalInterface
+interface Profiles {
+
+	/**
+	 * Test if this {@code Profiles} instance <em>matches</em> against the given
+	 * predicate.
+	 * @param isProfileActive a predicate that tests whether a given profile is currently
+	 * active
+	 */
+	boolean matches(Predicate<String> isProfileActive);
+
+	/**
+	 * Create a new {@link Profiles} instance that checks for matches against the given
+	 * <em>profile expressions</em>.
+	 * <p>
+	 * The returned instance will {@linkplain Profiles#matches(Predicate) match} if any
+	 * one of the given profile expressions matches.
+	 * <p>
+	 * A profile expression may contain a simple profile name (for example
+	 * {@code "production"}) or a compound expression. A compound expression allows for
+	 * more complicated profile logic to be expressed, for example
+	 * {@code "production & cloud"}.
+	 * <p>
+	 * The following operators are supported in profile expressions.
+	 * <ul>
+	 * <li>{@code !} - A logical <em>NOT</em> of the profile name or compound
+	 * expression</li>
+	 * <li>{@code &} - A logical <em>AND</em> of the profile names or compound
+	 * expressions</li>
+	 * <li>{@code |} - A logical <em>OR</em> of the profile names or compound
+	 * expressions</li>
+	 * </ul>
+	 * <p>
+	 * Please note that the {@code &} and {@code |} operators may not be mixed without
+	 * using parentheses. For example, {@code "a & b | c"} is not a valid expression: it
+	 * must be expressed as {@code "(a & b) | c"} or {@code "a & (b | c)"}.
+	 * <p>
+	 * Two {@code Profiles} instances returned by this method are considered equivalent to
+	 * each other (in terms of {@code equals()} and {@code hashCode()} semantics) if they
+	 * are created with identical <em>profile expressions</em>.
+	 * @param profileExpressions the <em>profile expressions</em> to include
+	 * @return a new {@link Profiles} instance
+	 */
+	static Profiles of(String... profileExpressions) {
+		return ProfilesParser.parse(profileExpressions);
+	}
+
+}

--- a/ezkv-boot/src/main/java/io/jstach/ezkv/boot/ProfilesParser.java
+++ b/ezkv-boot/src/main/java/io/jstach/ezkv/boot/ProfilesParser.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jstach.ezkv.boot;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Internal parser used by {@link Profiles#of}.
+ *
+ * @author Phillip Webb
+ * @author Sam Brannen
+ * @since 5.1
+ */
+final class ProfilesParser {
+
+	private ProfilesParser() {
+	}
+
+	static Profiles parse(String... expressions) {
+		if (expressions.length == 0) {
+			throw new IllegalArgumentException("Must specify at least one profile expression");
+		}
+		Profiles[] parsed = new Profiles[expressions.length];
+		for (int i = 0; i < expressions.length; i++) {
+			parsed[i] = parseExpression(expressions[i]);
+		}
+		return new ParsedProfiles(expressions, parsed);
+	}
+
+	private static Profiles parseExpression(String expression) {
+		if (expression.isBlank()) {
+			throw new IllegalArgumentException("Invalid profile expression [" + expression + "]: must contain text");
+		}
+		StringTokenizer tokens = new StringTokenizer(expression, "()&|!", true);
+		return parseTokens(expression, tokens);
+	}
+
+	private static Profiles parseTokens(String expression, StringTokenizer tokens) {
+		return parseTokens(expression, tokens, Context.NONE);
+	}
+
+	private static Profiles parseTokens(String expression, StringTokenizer tokens, Context context) {
+		List<Profiles> elements = new ArrayList<>();
+		Operator operator = null;
+		while (tokens.hasMoreTokens()) {
+			String token = tokens.nextToken().trim();
+			if (token.isEmpty()) {
+				continue;
+			}
+			switch (token) {
+				case "(" -> {
+					Profiles contents = parseTokens(expression, tokens, Context.PARENTHESIS);
+					if (context == Context.NEGATE) {
+						return contents;
+					}
+					elements.add(contents);
+				}
+				case "&" -> {
+					assertWellFormed(expression, operator == null || operator == Operator.AND);
+					operator = Operator.AND;
+				}
+				case "|" -> {
+					assertWellFormed(expression, operator == null || operator == Operator.OR);
+					operator = Operator.OR;
+				}
+				case "!" -> elements.add(not(parseTokens(expression, tokens, Context.NEGATE)));
+				case ")" -> {
+					Profiles merged = merge(expression, elements, operator);
+					if (context == Context.PARENTHESIS) {
+						return merged;
+					}
+					elements.clear();
+					elements.add(merged);
+					operator = null;
+				}
+				default -> {
+					Profiles value = equals(token);
+					if (context == Context.NEGATE) {
+						return value;
+					}
+					elements.add(value);
+				}
+			}
+		}
+		return merge(expression, elements, operator);
+	}
+
+	private static Profiles merge(String expression, List<Profiles> elements, @Nullable Operator operator) {
+		assertWellFormed(expression, !elements.isEmpty());
+		if (elements.size() == 1) {
+			return elements.get(0);
+		}
+		Profiles[] profiles = elements.toArray(new Profiles[0]);
+		return (operator == Operator.AND ? and(profiles) : or(profiles));
+	}
+
+	private static void assertWellFormed(String expression, boolean wellFormed) {
+		if (!wellFormed) {
+			throw new IllegalArgumentException("Malformed profile expression [" + expression + "]");
+		}
+	}
+
+	private static Profiles or(Profiles... profiles) {
+		return activeProfile -> Arrays.stream(profiles).anyMatch(isMatch(activeProfile));
+	}
+
+	private static Profiles and(Profiles... profiles) {
+		return activeProfile -> Arrays.stream(profiles).allMatch(isMatch(activeProfile));
+	}
+
+	private static Profiles not(Profiles profiles) {
+		return activeProfile -> !profiles.matches(activeProfile);
+	}
+
+	private static Profiles equals(String profile) {
+		return activeProfile -> activeProfile.test(profile);
+	}
+
+	private static Predicate<Profiles> isMatch(Predicate<String> activeProfiles) {
+		return profiles -> profiles.matches(activeProfiles);
+	}
+
+	private enum Operator {
+
+		AND, OR
+
+	}
+
+	private enum Context {
+
+		NONE, NEGATE, PARENTHESIS
+
+	}
+
+	private static class ParsedProfiles implements Profiles {
+
+		private final Set<String> expressions = new LinkedHashSet<>();
+
+		private final Profiles[] parsed;
+
+		ParsedProfiles(String[] expressions, Profiles[] parsed) {
+			Collections.addAll(this.expressions, expressions);
+			this.parsed = parsed;
+		}
+
+		@Override
+		public boolean matches(Predicate<String> activeProfiles) {
+			for (Profiles candidate : this.parsed) {
+				if (candidate.matches(activeProfiles)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		@Override
+		public boolean equals(@Nullable Object other) {
+			return (this == other
+					|| (other instanceof ParsedProfiles that && this.expressions.equals(that.expressions)));
+		}
+
+		@Override
+		public int hashCode() {
+			return this.expressions.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			if (this.expressions.size() == 1) {
+				return this.expressions.iterator().next();
+			}
+			return this.expressions.stream().map(this::wrap).collect(Collectors.joining(" | "));
+		}
+
+		private String wrap(String str) {
+			return "(" + str + ")";
+		}
+
+	}
+
+}

--- a/ezkv-boot/src/main/java/io/jstach/ezkv/boot/RandomVariables.java
+++ b/ezkv-boot/src/main/java/io/jstach/ezkv/boot/RandomVariables.java
@@ -32,7 +32,9 @@ record RandomVariables(Random source, KeyValuesEnvironment.Logger logger, String
 		if (!key.startsWith(prefix)) {
 			return null;
 		}
-		logger.debug(String.format("Generating random property for '%s'", key));
+		if (logger.isDebug()) {
+			logger.debug(String.format("Generating random property for '%s'", key));
+		}
 		return "" + getRandomValue(key.substring(prefix.length()));
 	}
 

--- a/ezkv-boot/src/test/java/io/jstach/ezkv/boot/EzkvConfigTest.java
+++ b/ezkv-boot/src/test/java/io/jstach/ezkv/boot/EzkvConfigTest.java
@@ -1,5 +1,7 @@
 package io.jstach.ezkv.boot;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -12,7 +14,9 @@ class EzkvConfigTest {
 				"logging.level.io.jstach.ezkv", "DEBUG");
 		EzkvConfig.setDefaultProperties(m);
 		var config = EzkvConfig.of();
-		config.reload();
+		// config.reload();
+
+		assertEquals("Hello", config.getProperty("DEMO"));
 
 	}
 

--- a/ezkv-boot/src/test/resources/application.properties
+++ b/ezkv-boot/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+_profiles=demo
+_load_child=classpath:/child.properties

--- a/ezkv-boot/src/test/resources/child.properties
+++ b/ezkv-boot/src/test/resources/child.properties
@@ -1,0 +1,2 @@
+_config.activate.on-profile=test|demo
+DEMO=Hello

--- a/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/DefaultKeyValuesSourceLoader.java
+++ b/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/DefaultKeyValuesSourceLoader.java
@@ -275,7 +275,8 @@ class DefaultKeyValuesSourceLoader implements KeyValuesSourceLoader {
 			return keyValues;
 		}
 		Predicate<KeyValue> keyValuePredicate = skipResourceKeys ? resourceParser::isResourceKey : kv -> false;
-		FilterContext context = new FilterContext(system.environment(), resource.parameters(), keyValuePredicate);
+		FilterContext context = new FilterContext(system.environment(), variables, resource.parameters(),
+				keyValuePredicate);
 		/*
 		 * Run implicit pre filters.
 		 */

--- a/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/DefaultSedParser.java
+++ b/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/DefaultSedParser.java
@@ -173,6 +173,13 @@ final class DefaultSedParser {
 
 	}
 
+	// enum ResultType {
+	// DELETE,
+	// IGNORE,
+	// UPDATE
+	// }
+	// record Result(ResultType type, String value) {}
+
 	sealed interface Command permits SubstitutionCommand, DeleteCommand {
 
 		@Nullable

--- a/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValue.java
+++ b/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValue.java
@@ -115,16 +115,40 @@ public record KeyValue(String key, String expanded, Meta meta) {
 	 * @return new key value.
 	 */
 	public KeyValue withKey(String key) {
+		if (key.equals(this.key))
+			return this;
 		return new KeyValue(key, expanded, meta);
 	}
 
 	/**
-	 * Creates a new {@code KeyValue} with an updated expanded value.
+	 * Creates a new {@code KeyValue} with an updated expanded value. <strong> NOTE that a
+	 * new keyvalue could have this expanded value changed (with a new key value) when
+	 * interpolated <em>which happens after each load of a resource</em>. </strong>. If
+	 * the value is to be changed permanetly which is usually done by a filter changing
+	 * the value of the key (and not the raw value) {@link #withSealedValue(String)}
+	 * should be called. The key value will no longer be re-interpolated with the raw
+	 * original.
 	 * @param expanded the new expanded value.
 	 * @return a new {@code KeyValue} with the updated expanded value.
 	 */
 	public KeyValue withExpanded(String expanded) {
+		if (expanded.equals(this.expanded))
+			return this;
 		return new KeyValue(key, expanded, meta);
+	}
+
+	/**
+	 * Because EZKV reinterpolates all loaded key values on each resource load to support
+	 * chaining the expanded value will changed based on {@link #raw()}. Thus if a filter
+	 * or something similar would like to change a value without changing the raw loaded
+	 * value this method should be used. Ideally filters should not add values to be
+	 * interpolated as that would be confusing and this call prevents that by setting the
+	 * {@link Flag#NO_INTERPOLATION}.
+	 * @param value expanded value that will not be replaced by interpolation.
+	 * @return a new key value.
+	 */
+	public KeyValue withSealedValue(String value) {
+		return addFlags(Set.of(Flag.NO_INTERPOLATION)).withExpanded(value);
 	}
 
 	/**

--- a/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesLoader.java
+++ b/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesLoader.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesResource.java
+++ b/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesResource.java
@@ -493,7 +493,7 @@ public sealed interface KeyValuesResource extends NamedKeyValuesSource, KeyValue
 	 * <ol>
 	 * <li> Checking resource parameter of {@value #SCHEMA_STDIN_PARAM} is <code>true</code>.
 	 * </li>
-	 * <li>Setting {@value #SCHEMA_STDIN_MAIN_ARG_PARAM} to 
+	 * <li>Setting {@value #SCHEMA_STDIN_MAIN_ARG_PARAM} to
 	 * {@linkplain KeyValuesEnvironment#getMainArgs() command line argument} to check if present.
 	 * </li>
 	 * <li>
@@ -553,6 +553,11 @@ public sealed interface KeyValuesResource extends NamedKeyValuesSource, KeyValue
 	 * akin to <code>String.join(expression)</code>
 	 */
 	public static final String FILTER_JOIN = "join";
+
+	/*
+	 * TODO filter target is messy. Ideally filters only work with keys. Perhaps OOB will
+	 * only allow sed substitution with a flag to make a value change.
+	 */
 
 	/**
 	 * This suffix on the end of the filter name will tell filters that support to target

--- a/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesServiceProvider.java
+++ b/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesServiceProvider.java
@@ -496,7 +496,6 @@ record DefaultLoaderContext(KeyValuesEnvironment environment, KeyValuesMediaFind
 	 * Finds a list of profiles based on context and passed in parameters.
 	 * @param parameters from resource or filter.
 	 * @return list of profiles
-	 * @throws FileNotFoundException
 	 */
 	static List<String> profiles(KeyValuesEnvironment environment, Variables variables, Parameters parameters) {
 		var vars = Variables.builder().add(parameters).add(variables.renameKey(environment::qualifyMetaKey)).build();

--- a/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesServiceProvider.java
+++ b/ezkv-kvs/src/main/java/io/jstach/ezkv/kvs/KeyValuesServiceProvider.java
@@ -280,6 +280,13 @@ public sealed interface KeyValuesServiceProvider {
 	 * The {@link #filter(FilterContext, KeyValues, Filter)} method performs the filtering
 	 * operation.
 	 * </p>
+	 *
+	 * <h2>Implementation Notes</h2>
+	 *
+	 * In general it is not recommend that filters change values of key values however if
+	 * a filter would like to modify the value of key value (not true modify since key
+	 * values are immutable but copy) {@link KeyValue#withSealedValue(String)} should be
+	 * used otherwise the value will be likely replaced by downstream interpolation.
 	 */
 	public non-sealed interface KeyValuesFilter extends KeyValuesServiceProvider {
 
@@ -312,7 +319,9 @@ public sealed interface KeyValuesServiceProvider {
 		 * looking up parameters. Defaults to empty string.
 		 */
 		public record Filter(String filter, String expression, String name) {
-
+			/*
+			 * TODO remove filter name
+			 */
 		}
 
 		/**

--- a/ezkv-kvs/src/test/java/io/jstach/ezkv/kvs/FiltersTest.java
+++ b/ezkv-kvs/src/test/java/io/jstach/ezkv/kvs/FiltersTest.java
@@ -67,7 +67,7 @@ class FiltersTest {
 		Filter filter = new Filter(filterName, expression, "blah");
 		var s = KeyValuesSystem.builder().build();
 		Predicate<KeyValue> ignore = kv -> false;
-		FilterContext context = new FilterContext(s.environment(), Parameters.of(Map.of()), ignore);
+		FilterContext context = new FilterContext(s.environment(), Variables.empty(), Parameters.of(Map.of()), ignore);
 		var result = s.filter().filter(context, kvs, filter).orElseThrow();
 		return result;
 	}

--- a/ezkv-kvs/src/test/java/io/jstach/ezkv/kvs/KeyValuesSystemTest.java
+++ b/ezkv-kvs/src/test/java/io/jstach/ezkv/kvs/KeyValuesSystemTest.java
@@ -104,6 +104,7 @@ class KeyValuesSystemTest {
 		@SuppressWarnings("null")
 		var kvs = KeyValuesSystem.builder()
 			.environment(environment)
+			.addPostFilter("sed_val", "s/REPLACE/works/")
 			.provider(new MyProvider()) //
 			.build() //
 			.loader() //
@@ -123,6 +124,7 @@ class KeyValuesSystemTest {
 					ref1=refValue
 					stuff=/home/kenny
 					blah=/home/kenny
+					implicit_filter=works
 					message=/home/kenny hello
 					profile1=loaded
 					profile1=loaded 2
@@ -146,6 +148,7 @@ class KeyValuesSystemTest {
 					ref1=refValue
 					stuff=/home/kenny
 					blah=/home/kenny
+					implicit_filter=works
 					message=/home/kenny hello
 					profile1=loaded
 					profile1=loaded 2
@@ -174,6 +177,7 @@ class KeyValuesSystemTest {
 					KeyValue[key='ref1', raw='refValue', expanded='refValue', source=Source[uri=provider:///MyProvider, reference=[key='_load_MyProvider0', in='provider:///'], index=1]]
 					KeyValue[key='stuff', raw='${user.home}', expanded='/home/kenny', source=Source[uri=classpath:/test-props/testLoader.properties, index=1]]
 					KeyValue[key='blah', raw='${MISSING:-${stuff}}', expanded='/home/kenny', source=Source[uri=classpath:/test-props/testLoader.properties, index=2]]
+					KeyValue[key='implicit_filter', raw='REPLACE', expanded='works', source=Source[uri=classpath:/test-props/testLoader.properties, index=3], flags=[NO_INTERPOLATION]]
 					KeyValue[key='message', raw='${stuff} hello', expanded='/home/kenny hello', source=Source[uri=classpath:/test-props/testLoader-child.properties, reference=[key='_load_child', in='classpath:/test-props/testLoader.properties'], index=1]]
 					KeyValue[key='profile1', raw='loaded', expanded='loaded', source=Source[uri=classpath:/test-props/testLoader-profile1.properties, reference=[key='_load_profiles0', in='profile.classpath:/test-props/testLoader-__PROFILE__.properties'], index=1]]
 					KeyValue[key='profile1', raw='loaded 2', expanded='loaded 2', source=Source[uri=classpath:/test-props/testLoader-profile2.properties, reference=[key='_load_profiles1', in='profile.classpath:/test-props/testLoader-__PROFILE__.properties'], index=1]]

--- a/ezkv-kvs/src/test/resources/test-props/testLoader.properties
+++ b/ezkv-kvs/src/test/resources/test-props/testLoader.properties
@@ -1,5 +1,6 @@
 stuff=${user.home}
 blah=${MISSING:-${stuff}}
+implicit_filter=REPLACE
 
 _load_child=classpath:/test-props/testLoader-child.properties?_flags=optional
 _param_child_custom=custom parameter for child


### PR DESCRIPTION
Spring has an interesting property key that can be placed in property files that will only allow the properties to be collected if the profile is activated:

```properties
spring.config.activate.on-profile=prod
ignore=me
```

For example if the above profile of prod is not set `ignore=me` will not be picked up.

While this could be done by regular filters the problem is that it would need to be specified on every resource call.

Enter implicit filters which get run on every resource load.